### PR TITLE
Application incomplete form features

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -11,27 +11,27 @@ class ApplicationsController < ApplicationController
   end
 
   def new
-    # @application = Application.new 
-    # Possibly use this to save form fills when an error occurs and redirects back to this new page
+    @application = Application.new
   end
 
   def create
-    
     new_app = Application.new(application_params)
     if new_app.save
       redirect_to "/applications/#{new_app.id}"
     else
-      flash[:notice] = "Application not created: Please fill out all fields."
-      redirect_to "/applications/new"
-      # render :new
-      # Don't understand the difference between render and redirect
+      flash[:notice] = "Application not created: Required information missing."
+      @application = Application.new(application_params)
+      @application.save
+      render :new
     end
   end
 
   private
 
   def application_params
-    params[:status] = 'In Progress'
-    params.permit(:name, :street, :city, :state, :zip_code, :description, :status)
+    params
+      .require(:application)
+      .permit(:name, :street, :city, :state, :zip_code, :description, :status)
+      .with_defaults(status: 'In Progress')
   end
 end

--- a/app/views/applications/new.html.erb
+++ b/app/views/applications/new.html.erb
@@ -1,6 +1,16 @@
 <h1>New Application</h1>
+<% if @application.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@application.errors.count, "error") %> prohibited this application from being saved:</h2>
+    <ul>
+      <% @application.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
 
-<%= form_with url: '/applications', method: :post, local: true  do |form| %>
+<%= form_with model: @application, url: '/applications', method: :post, local: true  do |form| %>
   <%= form.label :name %> <br>
   <%= form.text_field :name %>
   <br> <br>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
 
   <body>
     <% flash.each do |type, msg| %>
-      <div>
+      <div id=<%= "#{type}" %>>
         <%= msg %>
       </div>
     <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,12 +5,12 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
-# ApplicationPet.destroy_all
-# Application.destroy_all
-# Pet.destroy_all
-# Shelter.destroy_all
-# VeterinaryOffice.destroy_all
-# Veterinarian.destroy_all
+ApplicationPet.destroy_all
+Application.destroy_all
+Pet.destroy_all
+Shelter.destroy_all
+VeterinaryOffice.destroy_all
+Veterinarian.destroy_all
 @shelter_1 = Shelter.create(name: 'Aurora shelter', city: 'Aurora, CO', foster_program: false, rank: 9)
 @shelter_2 = Shelter.create(name: 'RGV animal shelter', city: 'Harlingen, TX', foster_program: false, rank: 5)
 @shelter_3 = Shelter.create(name: 'Fancy pets of Colorado', city: 'Denver, CO', foster_program: true, rank: 10)

--- a/spec/features/applications/new_spec.rb
+++ b/spec/features/applications/new_spec.rb
@@ -54,14 +54,29 @@ RSpec.describe 'Application New Form Page' do
           visit '/applications/new'
           
           click_button('Submit')
-          expect(current_path).to eq("/applications/new")
+          expect(page).to have_field('Name')
+          expect(page).to have_field('Street Address')
+          expect(page).to have_field('City')
+          expect(page).to have_field('State')
+          expect(page).to have_field('Zip Code')
+          expect(page).to have_field("Description of why you'd be a good home for this pet(s)")
+          expect(page).to have_button('Submit')
         end
 
         it 'And I see a message that I must fill in those fields' do
           visit '/applications/new'
           
           click_button('Submit')
-          expect(page).to have_content("Application not created: Please fill out all fields.")
+          
+          within('#notice') do
+            expect(page).to have_content("Application not created: Required information missing.")
+          end
+          expect(page).to have_content("Name can't be blank")
+          expect(page).to have_content("Street can't be blank")
+          expect(page).to have_content("City can't be blank")
+          expect(page).to have_content("State can't be blank")
+          expect(page).to have_content("Zip code can't be blank")
+          expect(page).to have_content("Description can't be blank")
         end
       end
     end


### PR DESCRIPTION
- update seeds to have destroy all resources so that running `rails s` will no longer populate on top of previous pops.
- modify applications controller 
- create action: add Application initialize and save instance so that application new `form_with` can be binded to model so that redirected invalid forms save old field data
- create action: change `redirect_to "/applications/new"` to `render :new` in order for form to utilize bindied instance model with old field data
- new action: added blank application instance `@application = Application.new` so that new form can have instance model to bind with on blank new forms
- modify applications new_spec tests to incorporate better error messages and allow for `render :new` functionality instead of redirect.
- modify applications new_spec tests to have within block test for flash message along with new error content
- modify `layouts/application.html.erb` so that div message block has an `id` of flash type

features and models specs are both at 100% coverage and passing